### PR TITLE
update calibration network information

### DIFF
--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -22,10 +22,10 @@ Developers can reference pre-existing deals that are already available on the ne
 
 ## Genesis
 
-* CAR File: `QmY581cXXtNwHweiC69jECupu9EBx274huHjSgxPNv1zAAj`
-* Reset Timestamp: `2021-02-19T23:10:00Z`
-* Genesis Block CID: `bafy2bzaceapb7hfdkewspic7udnogw4xnhjvhm74xy5snwa24forre5z4s2lm`
-* SHA-1 Digest: `944c0c13172b9f552dfed5dfaffaba95113c8254`
+* CAR File: `QmbHZuVjgtxvgtcE5H3FpE1ywEyawYmZcbx4Eh47WZ7YF8`
+* Reset Timestamp: `1667326380` (`2022-11-01T18:13:00Z`)
+* Genesis Block CID: `bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4`
+* SHA-1 Digest: `f9004d1266e0b023a018eb2fe6bb403cb8204df4`
 
 ## Network parameters
 
@@ -41,10 +41,10 @@ Developers can reference pre-existing deals that are already available on the ne
 ## Bootstrap peers
 
 ```plaintext
-/dns4/bootstrap-0.calibration.fildev.network/tcp/1347/p2p/12D3KooWRLZAseMo9h7fRD6ojn6YYDXHsBSavX5YmjBZ9ngtAEec
-/dns4/bootstrap-1.calibration.fildev.network/tcp/1347/p2p/12D3KooWJFtDXgZEQMEkjJPSrbfdvh2xfjVKrXeNFG1t8ioJXAzv
-/dns4/bootstrap-2.calibration.fildev.network/tcp/1347/p2p/12D3KooWP1uB9Lo7yCA3S17TD4Y5wStP5Nk7Vqh53m8GsFjkyujD
-/dns4/bootstrap-3.calibration.fildev.network/tcp/1347/p2p/12D3KooWLrPM4WPK1YRGPCUwndWcDX8GCYgms3DiuofUmxwvhMCn
+/dns4/bootstrap-0.calibration.fildev.network/tcp/1347/p2p/12D3KooWCi2w8U4DDB9xqrejb5KYHaQv2iA2AJJ6uzG3iQxNLBMy
+/dns4/bootstrap-1.calibration.fildev.network/tcp/1347/p2p/12D3KooWDTayrBojBn9jWNNUih4nNQQBGJD7Zo3gQCKgBkUsS6dp
+/dns4/bootstrap-2.calibration.fildev.network/tcp/1347/p2p/12D3KooWNRxTHUn8bf7jz1KEUPMc2dMgGfa4f8ZJTsquVSn3vHCG
+/dns4/bootstrap-3.calibration.fildev.network/tcp/1347/p2p/12D3KooWFWUqE9jgXvcKHWieYs9nhyp6NF4ftwLGAHm4sCv73jjK
 ```
 
 ## Snapshots


### PR DESCRIPTION
Calibration network was reset on 2022-11-01T18:13:00Z. The details in the docs are outdated. This PR updates it.

Sources:
https://calibration.filfox.info/en/tipset/0
https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi